### PR TITLE
Fix unsupported grep flag for BSD grep (-P flag)

### DIFF
--- a/kubeman
+++ b/kubeman
@@ -3,7 +3,7 @@
 kubectl "$@"
 
 if [ "$1" == "config" ] && [ "$2" == "use-context" ]; then
-  export client=($(kubectl version | grep -oP "(?<=GitVersion:\"v)(.*)(?=\", GitCommit)"))
+  export client=($(kubectl version | grep -Eo "GitVersion:\"v([0-9.]+)\"" | sed -E 's/GitVersion:"v([0-9.]+)"/\1/'))
 
   if [ -n "${client[1]}" ]; then
     server=($(echo ${client[1]} | tr "-" "\n"))

--- a/kubeman
+++ b/kubeman
@@ -13,7 +13,7 @@ if [ "$1" == "config" ] && [ "$2" == "use-context" ]; then
         echo "Downloading kubectl-$server"
         curl -L https://storage.googleapis.com/kubernetes-release/release/v"$server"/bin/linux/amd64/kubectl -o ~/.kube/kubectl-"$server"
       fi
-      cp ~/.kube/kubectl-"$server" /usr/local/bin/kubectl
+      sudo cp ~/.kube/kubectl-"$server" /usr/local/bin/kubectl
     fi
   fi
 fi


### PR DESCRIPTION
On mac, I can't use -P flag on grep because of BSD linux (not GNU). Add sed command to manually get captured group. Please test on your side using linux @firizki 